### PR TITLE
flatMap defined but did not use T

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@ contributors: Brian Terlson
     1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
     1. If _thisArg_ was supplied, let _T_ be _thisArg_; else let _T_ be *undefined*.
     1. Let _A_ be ? ArraySpeciesCreate(_O_, _len_).
-    1. Perform ? FlattenIntoArray(_A_, _O_, 0, _callbackFn_, _thisArg_).
+    1. Perform ? FlattenIntoArray(_A_, _O_, 0, _callbackFn_, _T_).
     1. Return _A_.
   </emu-alg>
 </emu-clause>


### PR DESCRIPTION
I assume it was intended as an argument to `FlattenIntoArray`; this fixes it.